### PR TITLE
[FIX] improve matlab demos and setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # data folder
 data/
 
+# example output folders
+example*outputs
+
 # various output
 figures/
 report.html

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,38 @@ venv.bak/
 .mypy_cache/
 
 # mat and npy files
-*.mat
 *.npy
+
+## added from https://github.com/github/gitignore/blob/main/Global/MATLAB.gitignore
+# Windows default autosave extension
+*.asv
+
+# OSX / *nix default autosave extension
+*.m~
+
+# Compiled MEX binaries (all platforms)
+*.mex*
+
+# Packaged app and toolbox files
+*.mlappinstall
+*.mltbx
+
+# Generated helpsearch folders
+helpsearch*/
+
+# Simulink code generation folders
+slprj/
+sccprj/
+
+# Matlab code generation folders
+codegen/
+
+# Simulink autosave extension
+*.autosave
+
+# Simulink cache files
+*.slxc
+
+# Octave session info
+octave-workspace
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "matlab/fracridge"]
+	path = matlab/fracridge
+	url = https://github.com/nrdg/fracridge.git
+	datalad-url = https://github.com/nrdg/fracridge.git

--- a/README.md
+++ b/README.md
@@ -23,11 +23,18 @@ raising a Github issue.
 
 ## MATLAB
 
-To use the GLMsingle toolbox, add it to your MATLAB path:
-  addpath(genpath('GLMsingle/matlab'));
+To install: 
 
-You will also need to download and add fracridge to your path.
-It is available here: https://github.com/nrdg/fracridge
+git clone --recurse-submodules https://github.com/cvnlab/GLMsingle.git
+
+This should also clone [`fracridge`](https://github.com/nrdg/fracridge)
+
+To use the GLMsingle toolbox, add it and `fracridge` to your MATLAB path by running:
+
+```matlab
+run setup.m
+```
+
 
 ## Example scripts
 

--- a/README.md
+++ b/README.md
@@ -25,16 +25,13 @@ raising a Github issue.
 
 To install: 
 
+```bash
 git clone --recurse-submodules https://github.com/cvnlab/GLMsingle.git
-
-This should also clone [`fracridge`](https://github.com/nrdg/fracridge)
-
-To use the GLMsingle toolbox, add it and `fracridge` to your MATLAB path by running:
-
-```matlab
-run setup.m
 ```
 
+This will also clone [`fracridge`](https://github.com/nrdg/fracridge) as a submodule.
+
+To use the GLMsingle toolbox, add it and `fracridge` to your MATLAB path by running the `setup.m` script.
 
 ## Example scripts
 

--- a/matlab/examples/.gitignore
+++ b/matlab/examples/.gitignore
@@ -1,2 +1,2 @@
-example1outputs
+example*outputs
 download

--- a/matlab/examples/.gitignore
+++ b/matlab/examples/.gitignore
@@ -1,0 +1,1 @@
+example1outputs

--- a/matlab/examples/.gitignore
+++ b/matlab/examples/.gitignore
@@ -1,2 +1,1 @@
-example*outputs
 download

--- a/matlab/examples/.gitignore
+++ b/matlab/examples/.gitignore
@@ -1,1 +1,2 @@
 example1outputs
+download

--- a/matlab/examples/download_data.m
+++ b/matlab/examples/download_data.m
@@ -10,7 +10,11 @@ function download_data(URL, input_file)
         try
           urlwrite(URL, input_file);
         catch
-          this_dir = fileparts(mfilename('fullfile'));
+          this_dir = fileparts(mfilename('fullfile'));          
+          if exist(fullfile(this_dir, 'download'), 'file')
+            % remove eventual previously incomplete downloads
+            delete(fullfile(this_dir, 'download'))
+          end
           system(sprintf('wget --verbose %s', URL)); 
           movefile(fullfile(this_dir, 'download'), input_file);
         end

--- a/matlab/examples/download_data.m
+++ b/matlab/examples/download_data.m
@@ -3,12 +3,18 @@ function download_data(URL, input_file)
   if  ~exist(input_file, 'file')
 
     % this fails on some machines ubuntu 18.04
-    % system(sprintf('curl -L --output %s %s', input_file, URL))
-    try
-      urlwrite(URL, input_file);
-    catch
-      system(sprintf('wget --verbose %s', URL)); 
-      movefile(fullfile(this_dir, 'download'), input_file);
+    if ispc
+        system(sprintf('curl -L --output %s %s', input_file, URL))
+    
+    else
+        try
+          urlwrite(URL, input_file);
+        catch
+          this_dir = fileparts(mfilename('fullfile'));
+          system(sprintf('wget --verbose %s', URL)); 
+          movefile(fullfile(this_dir, 'download'), input_file);
+        end
+    
     end
 
   end

--- a/matlab/examples/download_data.m
+++ b/matlab/examples/download_data.m
@@ -1,0 +1,16 @@
+function download_data(URL, input_file)
+  
+  if  ~exist(input_file, 'file')
+
+    % this fails on some machines ubuntu 18.04
+    % system(sprintf('curl -L --output %s %s', input_file, URL))
+    try
+      urlwrite(URL, input_file);
+    catch
+      system(sprintf('wget --verbose %s', URL)); 
+      movefile(fullfile(this_dir, 'download'), input_file);
+    end
+
+  end
+  
+end

--- a/matlab/examples/example1.m
+++ b/matlab/examples/example1.m
@@ -46,36 +46,33 @@
 
 %% Add dependencies and download the example dataset
 
-% We will assume that the current working directory is the directory that
-% contains this script.
-
-% Add path to GLMsingle
-addpath(genpath('../../matlab'));
-
-% You also need fracridge repository to run this code. For example, you
-% could do:
-%   git clone https://github.com/nrdg/fracridge.git
-% and then do:
-%   addpath('fracridge')
-
 % Start fresh
 clear
 clc
 close all
 
+
+this_dir = fileparts(mfilename('fullfile'));
+
+% Add path to GLMsingle
+run(fullfile(this_dir, '..','..','setup.m'));
+
 % Name of directory to which outputs will be saved
-outputdir = 'example1outputs';
+outputdir = fullfile(this_dir, 'example1outputs');
 
 % Download files to data directory
-if ~exist('./data','dir')
+input_dir = fullfile(this_dir, 'data');
+if ~exist(input_dir, 'dir')
     mkdir('data')
 end
 
-if ~exist('./data/nsdcoreexampledataset.mat','file')
-    % download data with curl
-    system('curl -L --output ./data/nsdcoreexampledataset.mat https://osf.io/k89b2/download')
-end
-load('./data/nsdcoreexampledataset.mat')
+input_file = fullfile(input_dir, 'nsdcoreexampledataset.mat');
+URL = 'https://osf.io/k89b2/download';
+
+download_data(URL, input_file);
+
+load(input_file)
+
 % Data comes from the NSD dataset (subj01, nsd01 scan session).
 % https://www.biorxiv.org/content/10.1101/2021.02.22.432340v1.full.pdf
 

--- a/matlab/examples/example1.m
+++ b/matlab/examples/example1.m
@@ -194,7 +194,9 @@ opt = struct('wantmemoryoutputs',[1 1 1 1]);
 % "example1outputs/GLMsingle". If these outputs don't already exist, we
 % will perform the time-consuming call to GLMestimatesingletrial.m;
 % otherwise, we will just load from disk.
-if ~exist([outputdir '/GLMsingle'],'dir')
+if ~exist(fullfile(outputdir, 'GLMsingle', 'TYPEB_FITHRF.mat'),'file') || ...
+   ~exist(fullfile(outputdir, 'GLMsingle', 'TYPEC_FITHRF_GLMDENOISE.mat'),'file') || ...
+   ~exist(fullfile(outputdir, 'GLMsingle', 'TYPED_FITHRF_GLMDENOISE_RR.mat'),'file')
     
     [results] = GLMestimatesingletrial(design,data,stimdur,tr,[outputdir '/GLMsingle'],opt);
     
@@ -289,7 +291,7 @@ opt.wantmemoryoutputs = [0 1 0 0];
 
 % If these outputs don't already exist, we will perform the call to
 % GLMestimatesingletrial.m; otherwise, we will just load from disk.
-if ~exist([outputdir '/GLMbaseline'],'dir')
+if ~exist(fullfile(outputdir, 'GLMbaseline', 'TYPEB_FITHRF.mat'),'file')
     
     [ASSUME_HRF] = GLMestimatesingletrial(design,data,stimdur,tr,[outputdir '/GLMbaseline'],opt);
     models.ASSUME_HRF = ASSUME_HRF{2};

--- a/matlab/examples/example1.m
+++ b/matlab/examples/example1.m
@@ -51,11 +51,10 @@ clear
 clc
 close all
 
-
-this_dir = fileparts(mfilename('fullfile'));
+this_dir = fileparts(mfilename('fullpath'));
 
 % Add path to GLMsingle
-run(fullfile(this_dir, '..','..','setup.m'));
+run(fullfile(this_dir, '..', '..', 'setup.m'));
 
 % Name of directory to which outputs will be saved
 outputdir = fullfile(this_dir, 'example1outputs');

--- a/matlab/examples/example2.m
+++ b/matlab/examples/example2.m
@@ -47,36 +47,31 @@
 
 %% Add dependencies and download the data
 
-% We will assume that the current working directory is the directory that
-% contains this script.
-
-% Add path to GLMsingle
-addpath(genpath('../../matlab'));
-
-% You also need fracridge repository to run this code. For example, you
-% could do:
-%   git clone https://github.com/nrdg/fracridge.git
-% and then do:
-%   addpath('fracridge')
-
 % Start fresh
 clear
 clc
 close all
 
+this_dir = fileparts(mfilename('fullfile'));
+
+% Add path to GLMsingle
+run(fullfile(this_dir, '..','..','setup.m'));
+
 % Name of directory to which outputs will be saved
-outputdir = 'example2outputs';
+outputdir = fullfile(this_dir, 'example2outputs');
 
 % Download files to data directory
-if ~exist('./data','dir')
+input_dir = fullfile(this_dir, 'data');
+if ~exist(input_dir, 'dir')
     mkdir('data')
 end
 
-if  ~exist('./data/nsdflocexampledataset.mat','file')
-    % download data with curl
-    system('curl -L --output ./data/nsdflocexampledataset.mat https://osf.io/g42tm/download')
-end
-load('./data/nsdflocexampledataset.mat')
+input_file = fullfile(input_dir, 'nsdflocexampledataset.mat');
+URL = 'https://osf.io/g42tm/download';
+
+download_data(URL, input_file);
+
+load(input_file)
 % Data comes from the NSD dataset (subj01, floc experiment, runs 1-4).
 % https://www.biorxiv.org/content/10.1101/2021.02.22.432340v1.full.pdf
 

--- a/matlab/examples/example2.m
+++ b/matlab/examples/example2.m
@@ -200,7 +200,9 @@ opt = struct('wantmemoryoutputs',[1 1 1 1]);
 % "example2outputs/GLMsingle". If these outputs don't already exist, we
 % will perform the time-consuming call to GLMestimatesingletrial.m;
 % otherwise, we will just load from disk.
-if ~exist([outputdir '/GLMsingle'],'dir')
+if ~exist(fullfile(outputdir, 'GLMsingle', 'TYPEB_FITHRF.mat'),'file') || ...
+   ~exist(fullfile(outputdir, 'GLMsingle', 'TYPEC_FITHRF_GLMDENOISE.mat'),'file') || ...
+   ~exist(fullfile(outputdir, 'GLMsingle', 'TYPED_FITHRF_GLMDENOISE_RR.mat'),'file')
     
     [results] = GLMestimatesingletrial(design,data,stimdur,tr,[outputdir '/GLMsingle'],opt);
     
@@ -293,7 +295,7 @@ opt.wantmemoryoutputs = [0 1 0 0];
 
 % If these outputs don't already exist, we will perform the call to
 % GLMestimatesingletrial.m; otherwise, we will just load from disk.
-if ~exist([outputdir '/GLMbaseline'],'dir')
+if ~exist(fullfile(outputdir, 'GLMbaseline', 'TYPEB_FITHRF.mat'),'file')
     
     [ASSUME_HRF] = GLMestimatesingletrial(design,data,stimdur,tr,[outputdir '/GLMbaseline'],opt);
     models.ASSUME_HRF = ASSUME_HRF{2};

--- a/matlab/examples/example2.m
+++ b/matlab/examples/example2.m
@@ -52,10 +52,10 @@ clear
 clc
 close all
 
-this_dir = fileparts(mfilename('fullfile'));
+this_dir = fileparts(mfilename('fullpath'));
 
 % Add path to GLMsingle
-run(fullfile(this_dir, '..','..','setup.m'));
+run(fullfile(this_dir, '..', '..', 'setup.m'));
 
 % Name of directory to which outputs will be saved
 outputdir = fullfile(this_dir, 'example2outputs');

--- a/setup.m
+++ b/setup.m
@@ -1,6 +1,18 @@
 % This script adds GLMsingle to the MATLAB path.
 
 % Add GLMsingle to the MATLAB path (in case the user has not already done so).
-path0 = strrep(which('setup.m'),'/setup.m','/matlab');
-addpath(genpath(path0));
-clear path0;
+GLMsingle_dir = fileparts(mfilename('fullfile'));
+
+addpath(fullfile(GLMsingle_dir, 'matlab'));
+addpath(fullfile(GLMsingle_dir, 'matlab', 'utilities'));
+
+% if the submodules were installed we try to add their code to the path
+addpath(fullfile(GLMsingle_dir, 'matlab', 'fracridge', 'matlab'));
+
+% check that the dependencies are in the path
+tmp = which('fracridge.m');
+if isempty(tmp)
+  error('fracridge is missing. Please install from: https://github.com/nrdg/fracridge.git')
+end
+
+clear GLMsingle_dir;


### PR DESCRIPTION
Fixes #29

- [x] tested on Linux (Ubuntu 18.04, Matlab 2017a)
- [x] tested on Windows (Windows 10, Matlab 2021a)
---
- [x] fix and refactor data download in demos to make it work on different OS
- [x] update gitignores to ignore examples outputs
- [x] improve setup and adapt README accordingly
  - [x] `fracridge` added as a submodule to avoid users having to install it manually and to "lock" of this required dependency
  - [x] fail early: thow error in  `setup` if `fracridge` is not found in the path
  - [x] only add the required folders to the path
  - [x] use setup script in examples