### PR TITLE
[DOC] Add sphinx documentation and serve on read the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
-#
+# vscode files
 .vscode/
 
+# test related
+tests/outputs/
 
-# data folder
+# data folders
 data/
 
 # example output folders
@@ -12,6 +14,9 @@ example*outputs
 figures/
 report.html
 ##*.png
+
+# pyenv
+Pipfile
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -54,6 +59,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+coverage_html
 .coverage.*
 .cache
 nosetests.xml
@@ -153,4 +159,3 @@ codegen/
 
 # Octave session info
 octave-workspace
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-yaml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 sphinx:
   configuration: docs/source/conf.py
   builder: html
-  fail_on_warning: true
+  fail_on_warning: false
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,26 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+  builder: html
+  fail_on_warning: true
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.6
+  install:
+    - requirements: requirements_dev.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# CONTRIBUTING
+
+Information for anyone who would like to contribute to this repository.
+
+## Repository map
+
+```bash
+├── .git
+├── .github
+│   └── workflows         # Github continuous integration set up
+├── examples
+│   ├── data
+│   ├── example1outputs
+│   ├── example2outputs
+├── glmsingle             # Python implementation
+│   ├── cod
+│   ├── design
+│   ├── gmm
+│   ├── hrf
+│   ├── ols
+│   ├── ssq
+│   └── utils
+├── matlab                # Matlab implementation
+│   ├── examples
+│   ├── fracridge
+│   └── utilities
+└── tests                 # Python and Matlab tests
+    └── data
+
+```
+
+## Generic
+
+### Makefile
+
+### pre-commit
+
+## Matlab
+
+### Style guide
+
+### Tests
+
+#### Demos
+
+### Continuous integration
+
+## Python
+
+### Style guide
+
+### Tests
+
+#### Demos
+
+### Continuous integration

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,116 @@
+.DEFAULT_GOAL := help
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+# TODO make more general to use the local matlab version
+MATLAB = /usr/local/MATLAB/R2017a/bin/matlab
+MATLAB_ARG    = -nodisplay -nosplash -nodesktop
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+# determines what "make help" will show
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+################################################################################
+# 	GENERIC
+.PHONY: help clean clean-test lint install_dev
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+clean: clean-build clean-pyc clean-test ## remove all build, test, coverage artifacts
+
+clean-test: ## remove test and coverage artifacts
+	rm -rf .tox/
+	rm -rf .coverage
+	rm -rf htmlcov/
+	rm -rf .pytest_cache
+	rm -rf tests/data
+	rm -rf test/outputs
+
+install_dev: ## install for both matlab and python developpers
+	pip install -e .
+	pip install -r requirements_dev.txt
+
+lint: lint/black lint/flake8 lint/miss_hit ## check style
+
+test: test-matlab test-python
+
+tests/data/nsdcoreexampledataset.mat: 
+	mkdir tests/data
+	curl -fsSL --retry 5 -o "tests/data/nsdcoreexampledataset.mat" https://osf.io/k89b2/download
+
+################################################################################
+
+################################################################################
+# 	MATLAB
+
+.PHONY: lint/miss_hit
+
+lint/miss_hit: ## lint and checks matlab code
+	mh_style --fix tests && mh_metric --ci tests && mh_lint tests
+
+test-matlab: tests/data/nsdcoreexampledataset.mat
+	$(MATLAB) $(MATLAB_ARG) -r "run_tests; exit()"
+
+coverage-matlab: test-matlab
+	$(BROWSER) coverage_html/index.html
+
+################################################################################
+
+################################################################################
+# 	PYTHON
+
+.PHONY: clean-build clean-pyc coverage-python install lint/flake8 lint/black
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+lint/flake8: ## check style with flake8
+	flake8 tests
+lint/black: ## check style with black
+	black tests
+
+test-python: tests/data/nsdcoreexampledataset.mat ## run tests quickly with the default Python
+	pytest 
+
+test-notebooks:
+	pytest  --nbmake --nbmake-timeout=3000 "./examples"
+test-all: ## run tests on every Python version with tox
+	tox
+
+coverage-python: ## check code coverage quickly with the default Python
+	coverage run --source glmsingle -m pytest
+	coverage report -m
+	coverage html
+	$(BROWSER) htmlcov/index.html
+
+install: clean ## install the package to the active Python's site-packages
+	python setup.py install
+
+################################################################################

--- a/README.md
+++ b/README.md
@@ -33,20 +33,6 @@ This will also clone [`fracridge`](https://github.com/nrdg/fracridge) as a submo
 
 To use the GLMsingle toolbox, add it and `fracridge` to your MATLAB path by running the `setup.m` script.
 
-## Example scripts
-
-We provide a number of example scripts that demonstrate usage of GLMsingle. You can browse these example scripts here:
-
-(Python Example 1 - event-related design) https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/examples/example1.html
-
-(Python Example 2 - block design) https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/examples/example2.html
-
-(MATLAB Example 1 - event-related design) https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/matlab/examples/example1preview/example1.html
-
-(MATLAB Example 2 - block design) https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/matlab/examples/example2preview/example2.html
-
-If you would like to run these example scripts, the Python versions are available in `/GLMsingle/examples`, and the MATLAB versions are available in `/GLMsingle/matlab/examples`. Each notebook contains a full walkthrough of the process of loading an example dataset and design matrix, estimating neural responses using GLMsingle, estimating the reliability of responses at each voxel, and comparing those achieved via GLMsingle to those achieved using a baseline GLM.
-
 ## Python
 
 To install: 
@@ -63,11 +49,24 @@ Running the demos requires:
 pip install jupyterlab
 ```
 
-Code dependencies: see requirements.txt
+Code dependencies: see [requirements.txt](./requirements.txt)
 
 Notes:
-* Please note that GLMsingle is not (yet) compatible with Python 3.9 (due to an incompatibility between scikit-learn and Python 3.9). Please use Python 3.8 or earlier.
 * Currently, numpy has a 4GB limit for the pickle files it writes; thus, GLMsingle will crash if the file outputs exceed that size. One workaround is to turn off "disk saving" and instead get the outputs of GLMsingle in your workspace and save the outputs yourself to HDF5 format.
+
+## Example scripts
+
+We provide a number of example scripts that demonstrate usage of GLMsingle. You can browse these example scripts here:
+
+(Python Example 1 - event-related design) https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/examples/example1.html
+
+(Python Example 2 - block design) https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/examples/example2.html
+
+(MATLAB Example 1 - event-related design) https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/matlab/examples/example1preview/example1.html
+
+(MATLAB Example 2 - block design) https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/matlab/examples/example2preview/example2.html
+
+If you would like to run these example scripts, the Python versions are available in `/GLMsingle/examples`, and the MATLAB versions are available in `/GLMsingle/matlab/examples`. Each notebook contains a full walkthrough of the process of loading an example dataset and design matrix, estimating neural responses using GLMsingle, estimating the reliability of responses at each voxel, and comparing those achieved via GLMsingle to those achieved using a baseline GLM.
 
 ## Additional information
 
@@ -79,6 +78,10 @@ Terms of use: This content is licensed under a BSD 3-Clause License.
 If you use GLMsingle in your research, please cite the following paper:
 
 * [Prince, J.S., Charest, I., Kurzawski, J.W., Pyles, J.A., Tarr, M.J., Kay, K.N. GLMsingle: a toolbox for improving single-trial fMRI response estimates. bioRxiv (2022).](https://www.biorxiv.org/content/10.1101/2022.01.31.478431v1)
+
+## Contributing
+
+If you want to contribute to GLMsingle see the [contributing](./CONTRIBUTING.md) documentation to help you know what is where and how to set things up.
 
 ## Change history
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,19 +12,24 @@
 #
 import os
 import sys
-root_dir = os.path.abspath('../..')
+
+root_dir = os.path.abspath("../..")
 sys.path.insert(0, root_dir)
 matlab_src_dir = root_dir
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'GLMsingle'
-copyright = '2022, Prince, J.S., Charest, I., Kurzawski, J.W., Pyles, J.A., Tarr, M.J., Kay, K.N.'
-author = 'Prince, J.S., Charest, I., Kurzawski, J.W., Pyles, J.A., Tarr, M.J., Kay, K.N.'
+project = "GLMsingle"
+copyright = """
+2022, Prince, J.S., Charest, I., Kurzawski, 
+J.W., Pyles, J.A., Tarr, M.J., Kay, K.N."""
+author = """
+Prince, J.S., Charest, I., Kurzawski, 
+J.W., Pyles, J.A., Tarr, M.J., Kay, K.N."""
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = "0.0.1"
 
 
 # -- General configuration ---------------------------------------------------
@@ -32,10 +37,10 @@ release = '0.0.1'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinxcontrib.matlab', 'sphinx.ext.autodoc']
+extensions = ["sphinxcontrib.matlab", "sphinx.ext.autodoc", "myst_parser"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -43,10 +48,10 @@ templates_path = ['_templates']
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -54,9 +59,9 @@ master_doc = 'index'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ["_static"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'GLMsingle'
+copyright = '2022, Prince, J.S., Charest, I., Kurzawski, J.W., Pyles, J.A., Tarr, M.J., Kay, K.N.'
+author = 'Prince, J.S., Charest, I., Kurzawski, J.W., Pyles, J.A., Tarr, M.J., Kay, K.N.'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,9 +10,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+root_dir = os.path.abspath('../..')
+sys.path.insert(0, root_dir)
+matlab_src_dir = root_dir
 
 
 # -- Project information -----------------------------------------------------
@@ -30,8 +32,7 @@ release = '0.0.1'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = ['sphinxcontrib.matlab', 'sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -41,13 +42,19 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'sphinx'
+
+# The master toctree document.
+master_doc = 'index'
+
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,11 +7,12 @@ Welcome to GLMsingle's documentation!
 =====================================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Contents:
 
    matlab
    python
+   wiki
 
 Indices and tables
 ==================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. GLMsingle documentation master file, created by
+   sphinx-quickstart on Sat Apr  9 11:02:56 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to GLMsingle's documentation!
+=====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,8 @@ Welcome to GLMsingle's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-
+   matlab
+   python
 
 Indices and tables
 ==================

--- a/docs/source/matlab.rst
+++ b/docs/source/matlab.rst
@@ -1,0 +1,6 @@
+MATLAB doc
+**********
+
+.. mat:automodule:: matlab
+
+.. mat:autofunction:: GLMestimatesingletrial

--- a/docs/source/matlab.rst
+++ b/docs/source/matlab.rst
@@ -4,3 +4,7 @@ MATLAB doc
 .. mat:automodule:: matlab
 
 .. mat:autofunction:: GLMestimatesingletrial
+
+.. mat:automodule:: matlab.utilities
+
+.. mat:autofunction:: calccod

--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -4,6 +4,10 @@ Python doc
 .. module:: glmsingle.glmsingle
 
 .. autoclass:: GLM_single
-.. module:: glmsingle.glmsingle
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
-.. autoclass:: GLM_single
+.. module:: glmsingle.cod.calc_cod
+
+.. autofunction:: calc_cod

--- a/docs/source/python.rst
+++ b/docs/source/python.rst
@@ -1,0 +1,9 @@
+Python doc
+**********
+
+.. module:: glmsingle.glmsingle
+
+.. autoclass:: GLM_single
+.. module:: glmsingle.glmsingle
+
+.. autoclass:: GLM_single

--- a/docs/source/wiki.md
+++ b/docs/source/wiki.md
@@ -1,0 +1,293 @@
+# WIKI
+
+## Basic information
+
+GLMsingle is introduced and described in the following pre-print:
+
+[Prince, J.S., Charest, I., Kurzawski, J.W., Pyles, J.A., Tarr, M.J., Kay, K.N. GLMsingle: a toolbox for improving single-trial fMRI response estimates. bioRxiv (2022).](https://doi.org/10.1101/2022.01.31.478431)
+
+GLMsingle is an analysis technique (an algorithm) for obtaining accurate
+estimates of single-trial beta weights in fMRI data.
+
+If you have questions or discussion points, please use the Discussions feature
+of this github repository, or alternatively, e-mail Kendrick (kay@umn.edu). If
+you find a bug, please let us know by raising a Github issue.
+
+## Example scripts
+
+We provide a number of example scripts that demonstrate usage of GLMsingle.
+
+You can browse these example scripts here:
+
+- [Python - example 1](https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/examples/example1.html)
+- [Python - example 2](https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/examples/example2.html)
+- [MATLAB - example 1](https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/matlab/examples/example1preview/example1.html)
+- [MATLAB - example 2](https://htmlpreview.github.io/?https://github.com/kendrickkay/GLMsingle/blob/main/matlab/examples/example2preview/example2.html)
+
+## Tips on usage
+
+### What's the deal with `sessionindicator`?
+
+If your experiment wants to analyze/combine data from multiple distinct scan
+sessions (multiple scanner visits), there is the possibility that after basic
+pre-processing, there may be substantial abrupt differences in percent BOLD
+signal change across responses observed on different days. The
+`sessionindicator` option allows you to tell the code how runs are grouped, and
+it will internally use this information to z-score responses within sessions in
+order to better estimate cross-validation performance. This normalization is
+just done internally (under the hood) and does not propagate to the final
+outputs.
+
+### Can I exert control over the noise pool voxels?
+
+The default behavior is to automatically select noise pool voxels based on
+passing a simple signal intensity threshold (i.e. a simple mask that ignores
+out-of-brain voxels) and on having very low amounts of BOLD variance related to
+the experiment (i.e. a "R<sup>2</sup>" threshold). If you want to specifically
+control the voxels that are used for the noise pool, you can achieve this by
+setting `brainthresh` to [99 0] (which allows all voxels to pass the intensity
+threshold), `brainR2` to 100 (which allows potentially all voxels in) and then
+setting `brainexclude` to be all voxels that you do NOT want in the noise pool.
+
+## FAQ
+
+### What are the main things that GLMsingle does?
+
+The main components of GLMsingle include:
+
+1. a "library of HRFs" technique where an empirically derived set of HRF
+   timecourses (from the subjects in the NSD dataset) are used as potential HRFs
+   for each voxel in your dataset,
+2. the GLMdenoise technique where data-driven nuisance regressors are obtained
+   and added into the GLM (using cross-validation for determining how many
+   nuisance regressors to add), and
+3. ridge regression as a way to improve robustness of single-trial beta
+   estimates. The technique relies on heavy amounts of computation, but is
+   implemented in a relatively efficient manner, and could therefore serve as a
+   go-to tool for deriving beta estimates from many types of fMRI experimental
+   data, and especially for condition-rich designs with few repeats per
+   condition.
+
+### How does GLMsingle achieve denoising?
+
+We can consider each of the three components.
+
+1. Mismodeling the timecourse of a voxel can lead to suboptimal results (i.e.
+   results that are, in a sense, "noisy"); GLMsingle attempts to remedy this by
+   using a well regularized HRF selection strategy where a simple "index" is
+   learned for each voxel.
+2. fMRI data suffer from very large amounts of spatially correlated noise (e.g.
+   due to head motion, physiological noise, etc.) --- by deriving these noise
+   sources from the data themselves, GLMsingle is able to provide some amount of
+   "modeling" out the noise.
+3. Finally, fMRI designs often involve substantial overlap of the response
+   across successive trials. From a statistical perspective, this is going to
+   hurt estimation efficiency. Ridge regression is a method that induces some
+   amount of shrinkage bias to help improve out-of-sample generalization.
+
+Note that these three components are heterogenous with regards to the idea of
+"fitting" the data. For the HRF component, the presumption is that we probably
+have at least enough data to estimate an HRF index for each voxel; hence the
+philosophy is to indeed fit the data. For the GLMdenoise component, the goal is
+to try to add regressors to the model to better fit the data, while
+acknowledging that at some point, overfitting is going to occur (and the
+algorithm attempts to determine that point). For the ridge regression component,
+things are a bit different. The point of ridge regression is to allow for the
+possibility that due to measurement noise, single-trial beta estimates are
+inaccurate and we want to actually limit the extent to which we fit the data.
+Thus, somewhat counter-intuitively, ridge regression _increases_ the residuals
+of the model fit.
+
+### In GLMsingle, the GLMdenoise and ridge regression (RR) components of the method require experimental conditions to repeat across runs. How should I think about whether this is appropriate for my experiment?
+
+In order to determine the hyperparameter settings, it is indeed necessary for
+some amount of repeated trials to exist in the data that are given to GLMsingle.
+It is true that, in a sense, any component of the fMRI data that does not repeat
+for the repeated trials associated with a condition is thought of a "noise" by
+the cross-validation process. Hence, there is some potential risk that
+components of interest might be removed. However, for the most part, we believe
+that the risk of this is actually minimal. This can be seen by thinking about
+the nature of the effects of GLMdenoise and ridge regression. GLMdenoise is
+simply trying to capture variance that appears to be spatially/globally
+correlated across voxels in the dataset; hence, its flexibility is actually
+quite limited. Ridge regression can only dampen the instabilities of beta
+estimates that persists across temporally nearby trials and in a uniform manner
+for all trials in the experiment; hence, its flexibility is also quite limited.
+
+### What are the metrics of quality that are relevant here?
+
+The philosophy behind GLMsingle lies primarily in cross-validation. Internal to
+the algorithm is the use of cross-validation to determine the two main
+"hyperparameters" that are used --- one is the number of nuisance regressors
+(which are derived via PCA on a noise pool of voxels) to add into the GLM model,
+and the other is the amount of ridge regularization to be applied to each voxel.
+The idea is that the hyperparameters that best generalize to the unregularized
+single-trial betas in some left-out data are the appropriate parameters to use.
+
+More generally, the quality metric being invoked here is "reliability" or
+"reproducibility". Typically, in an experiment you have experimental conditions
+that are presented multiple times. The assumption is that the signal induced by
+a given condition should reproduce across different trials.
+
+The concept of noise ceiling (described at length in the NSD data paper) is
+essentially a sophisticated method to quantify reliability. A simpler metric
+that can assess reliability is simply taking the responses obtained for a voxel
+and checking its reliability across different trials. For example, you could
+split the data into two halves and correlate the signal estimated on one half
+with the signal estimated on the other half.
+
+### I noticed that GLMsingle involves some internal cross-validation. Is this a problem for decoding-style analyses where we want to divide the data into a training set and a test set?
+
+It is true that GLMsingle makes use of all of the data that it is presented
+with: for example, if you give it 10 runs of time-series data, its outputs are
+dependent (in complex ways) on all of the data. However, we don't think that
+this poses any major "circularity"-type problems. All that the algorithm knows
+about are the onsets of your experimental conditions and some specification of
+when you think that conditions repeat, insofar that you expect some component of
+the response to be reproducible across trials. The repeats are used (in
+leave-one-run-out cross-validation) to determine the setting of the
+hyperparameters. GLMsingle has no access to your scientific hypotheses, and it
+is hard to see how it could bias the single-trial beta estimates in favor of one
+hypothesis over another. There is one exception, however. If the primary outcome
+you are trying to demonstrate is that responses to the same condition are
+reliable across runs, then that is, in a sense, exactly what the algorithm is
+trying to achieve --- so in that scenario, you might not want to give all of the
+data to GLMsingle. Instead, you could divide your data into two halves (for
+example), independently give each half to GLMsingle, and then test your
+hypothesis that indeed responses are reliable across the two halves.
+
+### I noticed that GLMsingle needs some conditions to repeat across runs. But my experiment is not fully balanced in this regard (or I have just a few repeats). Is this a problem?
+
+In general, we don't think that perfect balancing is that critical. The reason
+lies in thinking about the nature of the technique --- the repeats are simply
+used to set the hyperparameters (number of nuisance regressors; fractional
+regularization amount for each voxel). In our experience, even just a handful of
+repeats appears to be sufficient to robustly guide the estimation of the
+hyperparameters. Thus, even if you can code only a subset of the trials in your
+experiment as condition repeats, this may be sufficient to guide the
+hyperparameter estimation, and the overall results from GLMsingle might be quite
+good. (In fact, there are very few repeats in the NSD and BOLD5000 datasets,
+which are the main two datasets demonstrated in the GLMsingle pre-print.)
+
+### How does R<sup>2</sup> start becoming meaningful in the full FITHRF_GLMDENOISE_RR version?
+
+For a single-trial design matrix, note that in a sense the predictors are
+extremely flexible and are happy to capture essentially all or almost all of the
+variance in the time-series data from a voxel, even if that voxel contains no
+actual signal. Thus, for `ASSUMEHRF` or `FITHRF` or `FITHRF_GLMDENOISE` type
+models, the R<sup>2</sup> values from these models are more or less meaningless
+(everything looks "good"). However, the RR technique (as a direct consequence of
+the fact that it will shrink betas to 0 in accordance to the cross-validated
+generalizability of the single-trial beta estimates) will essentially leave
+unperturbed the good voxels that have good SNR and aggressively shrink the bad
+voxels with little or no SNR. As a consequence, the variance explained by the
+beta estimates that are produced by ridge regression will be directly related to
+the "goodness" of the voxel as determined by the cross-validation procedure.
+Thus, the ridge regression results will have high R<sup>2</sup> values for the
+voxels that seem to have reproducible beta estimates across runs.
+
+### Why does ridge regression improve beta estimates?
+
+Ridge regression imposes a shrinkage prior on regression weights, with the exact
+amount of regularization controlled by the hyperparameter. In regression
+problems where there are correlations across the predictors, ordinary
+least-squares estimates of regression weights are unbiased but can suffer from
+high variance (i.e. affected by noise). By imposing some amount of shrinkage,
+the ability of the estimated regression weights to be more generalizable to
+unseen data can be improved. However, these are general statistical concepts. In
+the specific case of fMRI designs involving closely spaced trials, there are
+high levels of positive correlations between temporally adjacent trials. In a
+sense, you can think of this situation as there being limited amounts of data
+(statistical power) to disentangle the responses due to adjacent trials.
+Ordinary least squares tries to estimate these responses but will generally lead
+to noisy beta estimates with large magnitudes (either positive and/or negative).
+Ridge regression allows the estimation to impose a prior that effectively
+downweights the noisy and limited amounts of data that inform the distinction
+between adjacent trials; we can view it as imposing some amount of "temporal
+smoothing" (pushing the beta weights from adjacent trials to be more similar in
+magnitude) with the goal of attaining an overall solution that has better
+out-of-sample performance. Also, in GLMsingle, note that a different shrinkage
+hyperparameter is selected for each voxel: this is important since voxels vary
+substantially in their signal-to-noise ratios.
+
+### What are the units of the single-trial beta weights, and are there any interpretation issues?
+
+The default behavior of GLMsingle is to return beta weights in units of percent
+signal change (by dividing by the mean signal intensity observed at each voxel
+and multiplying by 100). However, there can be tricky issues having to do with
+the selection of the HRF. If the HRF used in a GLM is incorrect or different
+from the underlying HRF, there can easily be gross "gain" or "scale" differences
+in the obtained percent signal change units of the betas. One of the things that
+GLMsingle attempts to do for you is to estimate a more proper HRF timecourse (as
+opposed to assuming a canonical HRF). It is the case that depending on how you
+use GLMsingle, you may encounter some scale issues. For example, if you use
+GLMsingle to analyze data from one scan session and then separately analyze data
+from a second scan session, there will likely be some differences across the two
+sets of results. First, there could be real (physiological) changes in the
+percent signal change across different days. Second, each set of results may
+have a different HRF identified and used for a given voxel; thus, the percent
+signal change units in the betas for a given voxel will have a different
+ultimate meaning for the two sets of results. It is an open question how to
+"best" normalize or handle the betas from different scan sessions to more
+accurately get at the underlying neural activity. However, a quick and dirty
+heuristic is to normalize the betas, e.g., by z-scoring, or scaling, depending
+on your overall scientific goals.
+
+### If the HRF changes from voxel to voxel (or area to area), doesn't that pose some interpretation difficulties or confounding issues?
+
+This is an important issue. In essence, what's at stake is the interpretation of
+the absolute magnitudes of beta weights that are derived from a GLM analysis.
+Typically, the amplitude of an evoked hemodynamic response is expressed in terms
+of percent signal change (PSC) (e.g. by dividing the amplitude increase by some
+baseline signal level and then multiplying by 100). Now, if all
+voxels/areas/subjects shared exactly the same hemodynamic timecourse shape (i.e.
+HRF) and we used this HRF in the analysis, then things would be easy. However,
+there are real differences in timecourse shape across voxels/areas/subjects.
+(And timecourses can actually also change across scan sessions for the same
+voxel(s), due to physiology changes.) Thus, an approach that just assumes a
+single fixed HRF has the advantage of being easy to think about, but already
+will produce biases in PSC magnitudes. (For example, if you just change the
+single fixed HRF used in an analysis, you will likely see that some voxel's
+magnitudes go up and other voxels' magnitudes go down.) Now, consider the
+approach of tailoring the HRF used in the analysis for individual voxels.
+Certainly, the interpretation has to follow carefully -- the set of betas we
+observe from a given voxel needs to be interpreted as the amplitude of responses
+that appear to be present in the data _assuming_ the HRF selected for that
+voxel. Note that in GLMsingle, the library of HRFs are normalized such that the
+peak HRF value is 1 for each of the HRFs, so you can conveniently think of the
+betas that result for a given HRF as literally the amplitude. Nonetheless, it
+remains an open question how much we can actually interpret differences in BOLD
+amplitudes across voxels/areas. For example, if one region seems to have higher
+PSC than another region (even within the same subject), this doesn't necessarily
+mean that the underlying local neural activity is actually higher in the first
+region. Finally, we note that one approach to "get rid" of these types of
+amplitude issues is to normalize (e.g. z-score) the responses you observe from a
+voxel (or region) over the course of a scan session. Of course, one should think
+carefully about the implications of such an approach for downstream analyses...
+
+### What is the interpretation of the scale and offset?
+
+By default, after the application of ridge regression, GLMsingle applies a
+post-hoc scale and offset to the single-trial betas obtained for a given voxel
+to best match what is obtained in the unregularized case. The reason for this is
+that due to shrinkage, the betas for a voxel are generally "shrunken" down close
+to 0, and therefore have some bias to be small in size. The theory is that we
+can undo some of the bias by applying a simple scale and offset to the beta
+weights. For many post-hoc uses of the beta estimates, a scale and offset is
+probably not a big deal, but certainly one should think hard about whether or
+not this matters to the analyses you are trying to do. One can always omit the
+scale and offset (via appropriate setting of input options) and/or avoid ridge
+regression altogether.
+
+### In the NSD data paper, in the calculation of the noise ceiling, the beta weights are z-scored. What's going on there?
+
+The NSD experiment involves aggregating responses across many distinct scan
+sessions. Z-scoring is proposed as a potential (simple) method to reduce
+instabilities that exist across different scan sessions. Obviously, z-scoring
+can throw away relevant information, so one should be careful in that regard.
+
+## Things to watch out for
+
+If you use the input option to use a canonical HRF (instead of the library of
+HRFs), the filename that is written is still "`FITHRF`" (even though the results
+reflect what the user specified).

--- a/matlab/utilities/calccod.m
+++ b/matlab/utilities/calccod.m
@@ -1,29 +1,37 @@
 function f = calccod(x,y,dim,wantgain,wantmeansub,wantsafe)
-
-% function f = calccod(x,y,dim,wantgain,wantmeansub,wantsafe)
+%
+% USAGE::
+% 
+%   f = calccod(x,y,dim,wantgain,wantmeansub,wantsafe)
 %
 % <x>,<y> are matrices with the same dimensions
+%
 % <dim> (optional) is the dimension of interest.
-%   default to 2 if <x> is a (horizontal) vector and to 1 if not.
-%   special case is 0 which means to calculate globally.
+% default to 2 if <x> is a (horizontal) vector and to 1 if not.
+% special case is 0 which means to calculate globally.
+%
 % <wantgain> (optional) is
-%   0 means normal
-%   1 means allow a gain to be applied to each case of <x>
+%
+%   - 0 means normal
+%   - 1 means allow a gain to be applied to each case of <x>
 %     to minimize the squared error with respect to <y>.
 %     in this case, there cannot be any NaNs in <x> or <y>.
-%   2 is like 1 except that gains are restricted to be non-negative.
+%   - 2 is like 1 except that gains are restricted to be non-negative.
 %     so, if the gain that minimizes the squared error is negative,
 %     we simply set the gain to be applied to be 0.
-%   default: 0.
+%     default: 0.
+%
 % <wantmeansub> (optional) is
-%   0 means do not subtract any mean.  this makes it such that
+%
+%   - 0 means do not subtract any mean.  this makes it such that
 %     the variance quantification is relative to 0.
-%   1 means subtract the mean of each case of <y> from both
+%   - 1 means subtract the mean of each case of <y> from both
 %     <x> and <y> before performing the calculation.  this makes
 %     it such that the variance quantification
 %     is relative to the mean of each case of <y>.
 %     note that <wantgain> occurs before <wantmeansub>.
-%   default: 1.
+%     default: 1.
+%
 % <wantsafe> (optional) is whether to protect against NaNs. Default: 1.
 %
 % calculate the coefficient of determination (R^2) indicating
@@ -45,18 +53,23 @@ function f = calccod(x,y,dim,wantgain,wantmeansub,wantsafe)
 % if there are no valid data points (i.e. all data points are
 % ignored because of NaNs), we return NaN for that case.
 %
-% note some weird cases:
-%   calccod([],[]) is []
+% Note some weird cases: 
+% 
+% calccod([],[]) is []
 %
+% Example::
+%
+%   x = randn(1,100);
+%   calccod(x,x+0.1*randn(1,100))
+%
+
+
 % history:
 % 2013/08/18 - fix pernicious case where <x> is all zeros and <wantgain> is 1 or 2.
 % 2010/11/28 - add <wantgain>==2 case
 % 2010/11/23 - changed the output range to percentages.  thus, the range is (-Inf,100].
 %              also, we removed the <wantr> input since it was dumb.
-%
-% example:
-% x = randn(1,100);
-% calccod(x,x+0.1*randn(1,100))
+
 
 % input
 if ~exist('dim','var') || isempty(dim)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,3 +9,7 @@ pytest
 black
 nbmake
 pytest-cov
+
+# Documentation
+sphinx
+sphinxcontrib-matlabdomain

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,6 @@
+# Base requirements
+requirements.txt
+
 # Matlab dev
 miss_hit 
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 # Base requirements
-requirements.txt
+-r requirements.txt
 
 # Matlab dev
 miss_hit 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,3 +17,4 @@ pytest-cov
 sphinx
 sphinxcontrib-matlabdomain
 sphinx_rtd_theme
+myst-parser

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,3 +13,4 @@ pytest-cov
 # Documentation
 sphinx
 sphinxcontrib-matlabdomain
+sphinx_rtd_theme

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,11 @@
+# Matlab dev
+miss_hit 
+
+# Python dev
+flake8
+tox
+coverage
+pytest
+black
+nbmake
+pytest-cov


### PR DESCRIPTION
Small example of a set up to use the Sphinx python package to automatically generate the documentation of the code by reading it from the doc stings (python) or help section (matlab).

This also includes a setup to serve the doc on read the docs.
See the output here: https://glmsingle.readthedocs.io/en/latest/

This example only shows the rendering of the main function but this could be expanded to add more of the utilities function.

Pros: easy to create a website to point users to or even a pdf of the whole documentation (`make latexpdf`)

Cons: might require to do a light editing of the comments in the code to make them play well with reStructured text (the markup language used by Sphinx) otherwise the rendering is suboptimal.

For a quick intro to all this: https://goodresearch.dev/docs.html#

FYI this is based on the same initial commit as #43 and #44
 