### PR TITLE
debug extra_regressors functionality for python version

### DIFF
--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -489,7 +489,9 @@ class GLM_single():
             True,
             err_msg='fracs must be less than or equal to 1')
 
-        assert len(params['extra_regressors']) == numruns, '<extra_regressors> should match the number of runs'
+        if params['extra_regressors']:
+            if params['extra_regressors'][0] is not False:
+                assert len(params['extra_regressors']) == numruns, '<extra_regressors> should match the number of runs'
 
         if figuredir is not None:
             wantfig = 1  # if outputdir is not None, we want figures
@@ -1341,7 +1343,7 @@ class GLM_single():
                             }
                             if n_pc > 0:
                                 for rr in range(numruns):
-                                    if not params['extra_regressors'] or \
+                                    if not params['extra_regressors'][0] or \
                                         not np.any(params['extra_regressors'][rr]):
 
                                         optA['extra_regressors'][rr] = \
@@ -1537,7 +1539,7 @@ class GLM_single():
 
                             if pcnum > 0:
                                 for run_i in range(numruns):
-                                    if not params['extra_regressors'] or \
+                                    if not params['extra_regressors'][0] or \
                                         not np.any(params['extra_regressors'][run_i]):
 
                                         optA['extra_regressors'][run_i] = \

--- a/glmsingle/ols/glm_estimatemodel.py
+++ b/glmsingle/ols/glm_estimatemodel.py
@@ -453,7 +453,7 @@ def glm_estimatemodel(design, data, stimdur, tr, hrfmodel, hrfknobs,
     if opt is None:
         opt = {}
 
-    if 'extra_regressors' not in opt or opt['extra_regressors'] is False or opt['extra_regressors'] == []:
+    if 'extra_regressors' not in opt or opt['extra_regressors'][0] is False or not np.any(opt['extra_regressors'][0]):
         opt['extra_regressors'] = [None for x in range(numruns)]
 
     if 'maxpolydeg' not in opt:


### PR DESCRIPTION
for handling extra_regressors, the python functionality added in https://github.com/cvnlab/GLMsingle/commit/a8dda4c454444a93d2d3888361e7efc085c38770 was buggy, causing example01 to fail. (see issue: https://github.com/cvnlab/GLMsingle/issues/125). this commit fixes the implementation.