### PR TITLE
Bug in saving HDF5 file with None values

### DIFF
--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -1708,7 +1708,13 @@ class GLM_single():
                 if params['wanthdf5'] == 1:
                     hf = h5py.File(file0, 'w')
                     for k, v in outdict.items():
-                        hf.create_dataset(k, data=v)
+                        if isinstance(v, list):
+                            v = np.array(v)
+                        if v is not None:
+                            hf.create_dataset(k, data=v)
+                        else:
+                            msg = f"Skipping key '{k}' because its value is None or unsupported: {v}"
+                            warnings.warn(msg)
                     hf.close()
                 else:
                     np.save(file0, outdict)


### PR DESCRIPTION
Hi, I encountered a bug when saving HDF5 files. I am running GLMsingle in Python without standard cross-validation (i.e., a fixed pcstop and fracs value). I am using the most recent version of GLMsingle.

Here is the error message:

```
Traceback (most recent call last):
  File "evaluate_GLMsingle_focal.py", line 259, in <module>
    main()
  File "evaluate_GLMsingle_focal.py", line 237, in main
    results_glmsingle = glmsingle_obj.fit(
  File "/om2/user/gretatu/anaconda/envs/glmsinglev2/lib/python3.8/site-packages/glmsingle/glmsingle.py", line 1711, in fit
    hf.create_dataset(k, data=v)
  File "/om2/user/gretatu/anaconda/envs/glmsinglev2/lib/python3.8/site-packages/h5py/_hl/group.py", line 183, in create_dataset
    dsid = dataset.make_new_dset(group, shape, dtype, data, name, **kwds)
  File "/om2/user/gretatu/anaconda/envs/glmsinglev2/lib/python3.8/site-packages/h5py/_hl/dataset.py", line 52, in make_new_dset
    raise TypeError("One of data, shape or dtype must be specified")
TypeError: One of data, shape or dtype must be specified
```

I fixed it via the PR (not saving values that are None).
I also added some print statements in my code, and these values seemed problematic:

```
Warning: Skipping key 'glmbadness' because its value is None or unsupported: None
Warning: Skipping key 'pcvoxels' because its value is None or unsupported: None
Warning: Skipping key 'xvaltrend' because its value is None or unsupported: None
Warning: Converting list to numpy array for key 'pcregressors', shape of values: (8, 170, 11)
Warning: Converting list to numpy array for key 'rrbadness', shape of values: (0,)
```
(should I be worried? Is this unexpected, or simply a bug in saving values that do not exist in the non-cross-validated use case?)

I ran:

results_glmsingle = glmsingle_obj.fit(
    design,
    data,
    stimdur,
    tr,
    outputdir=OUTPUTDIR)

where design is a list of length 8, with numpy arrays of shape (170; 400), data is a list of length 8 with numpy arrays of shape (91; 109; 91; 170), stimdur is 2 and tr is 2.

The opt params are:

{'R2thresh': 0,
 'brainR2': [],
 'brainexclude': False,
 'brainthresh': [99.0, 0.1],
 'chunklen': 50000,
 'extra_regressors': False,
 'fracs': 0.05,
 'hrffitmask': 1,
 'hrfmodel': 'optimise',
 'hrfthresh': 0.5,
 'lambda': 0,
 'n_boots': 100,
 'n_jobs': 1,
 'n_pcs': 10,
 'numforhrf': 50,
 'pcR2cutoff': [],
 'pcR2cutoffmask': 1,
 'pcstop': -5,
 'seed': 1708355214.6366038,
 'suppressoutput': 0,
 'wantautoscale': 1,
 'wantfileoutputs': [1, 1, 1, 1],
 'wantfracridge': 1,
 'wantglmdenoise': 1,
 'wanthdf5': 1,
 'wantlibrary': 1,
 'wantlss': 0,
 'wantmemoryoutputs': [1, 1, 1, 1],
 'wantparametric': 0,
 'wantpercentbold': 1}
 
 Thanks a lot :)