### PR TITLE
Bugfix for elementwise comparison

### DIFF
--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -1345,9 +1345,8 @@ class GLM_single():
                             }
                             if n_pc > 0:
                                 for rr in range(numruns):
-                                    if not params['extra_regressors'][0] or \
+                                    if params['extra_regressors'][0] is False or \
                                         not np.any(params['extra_regressors'][rr]):
-
                                         optA['extra_regressors'][rr] = \
                                             pcregressors[rr][:, :n_pc]
                                     else:
@@ -1541,7 +1540,7 @@ class GLM_single():
 
                             if pcnum > 0:
                                 for run_i in range(numruns):
-                                    if not params['extra_regressors'][0] or \
+                                    if params['extra_regressors'][0] is False or \
                                         not np.any(params['extra_regressors'][run_i]):
 
                                         optA['extra_regressors'][run_i] = \


### PR DESCRIPTION
I think the current version of glmsingle is not compatible with the latest numpy, due to the element-wise comparison using `not`. There  already was a commit that was supposed to solve this (https://github.com/cvnlab/GLMsingle/commit/f19593db6f3be5ce846e90317a0620ae5507bc13), but I still had issues. I think my commit now solves all of these...

