### PR TITLE
fixed bug when no repeats exist and user wants glmdenoise or fracridge

### DIFF
--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -665,16 +665,27 @@ class GLM_single():
             warnings.warn(msg)
 
             if params['wantglmdenoise']:
-                msg = 'Since there are no repeats, standard cross-validation usage of' + \
-                    ' <wantglmdenoise> cannot be performed. Setting <wantglmdenoise> to 0.'
-                warnings.warn(msg)
-                params['wantglmdenoise'] = 0;
+                if params['pcstop'] <= 0:
+                    msg = 'pcstop is specified as the -B case. We will not be performing ' + \
+                          'cross-validation, but will be performing glmdenoise using B number of PCs'
+                    warnings.warn(msg)
+                else:
+                    msg = 'Since there are no repeats, standard cross-validation usage of ' + \
+                          '<wantglmdenoise> cannot be performed. Setting <wantglmdenoise> to 0.'
+                    warnings.warn(msg)
+                    params['wantglmdenoise'] = 0
 
             if params['wantfracridge']:
-                msg = 'Since there are no repeats, standard cross-validation usage of' + \
-                    ' <wantfracridge> cannot be performed. Setting <wantfracridge> to 0.'
-                warnings.warn(msg)
-                params['wantfracridge'] = 0;
+                if len(params['fracs']) > 1:
+                    msg = 'Since there are no repeats, standard cross-validation usage of' + \
+                        ' <wantfracridge> cannot be performed. Setting <wantfracridge> to 0.'
+                    warnings.warn(msg)
+                    params['wantfracridge'] = 0
+                else:
+                    msg = 'fracs is specified as the single scalar case. We will not be' + \
+                        'performing cross-validation, but will be performing ridge regression ' + \
+                        'using the user-supplied fraction'
+                    warnings.warn(msg)
 
         # Construct a nice output dictionary for this design-related stuff
         resultsdesign = {

--- a/matlab/GLMestimatesingletrial.m
+++ b/matlab/GLMestimatesingletrial.m
@@ -703,12 +703,20 @@ end
 if all(condinruns <= 1)
   warning('None of your conditions occur in more than one run. Are you sure this is what you intend?');
   if opt.wantglmdenoise
-    warning('Since there are no repeats, standard cross-validation usage of <wantglmdenoise> cannot be performed. Setting <wantglmdenoise> to 0.');
-    opt.wantglmdenoise = 0;
+    if opt.pcstop <= 0
+      warning('pcstop is specified as the -B case. We will not be performing cross-validation, but will be performing glmdenoise using B number of PCs');
+    else
+      warning('Since there are no repeats, standard cross-validation usage of <wantglmdenoise> cannot be performed. Setting <wantglmdenoise> to 0.');
+      opt.wantglmdenoise = 0;
+    end
   end
   if opt.wantfracridge
-    warning('Since there are no repeats, standard cross-validation usage of <wantfracridge> cannot be performed. Setting <wantfracridge> to 0.');
-    opt.wantfracridge = 0;
+    if length(opt.fracs)==1
+      warning('fracs is specified as the single scalar case. We will not be performing cross-validation, but will be performing ridge regression using the user-supplied fraction');
+    else
+      warning('Since there are no repeats, standard cross-validation usage of <wantfracridge> cannot be performed. Setting <wantfracridge> to 0.');
+      opt.wantfracridge = 0;
+    end
   end
 end
 


### PR DESCRIPTION
fixed logic in glmsingle.py and glmestimatesingletrial.m to ensure that glmdenoise and fracridge still run when there are no repeats, if the user has set the pcstop or fracs hyperparameters to special case values. 