### PR TITLE
fixed bug arising from scipy.interp1d

### DIFF
--- a/glmsingle/utils/cmapturbo.py
+++ b/glmsingle/utils/cmapturbo.py
@@ -38,7 +38,7 @@ def cmapturbo(n=256):
     # do it
     f = []
     for p in range(nchan):
-      f.append(interp1d(range(ncols), cols[:,p].T)(xx))
+      f.append(np.interp(xx, range(ncols), cols[:,p].T)) 
 
     return np.asarray(f).T
     


### PR DESCRIPTION
deals with case where indexing exceeds maximum color in colormap due to precision issues, as in issue #137 