### PR TITLE
fixed bug in h5py dataset saving when fields are None

### DIFF
--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -914,7 +914,12 @@ class GLM_single():
             if params['wanthdf5'] == 1:
                 hf = h5py.File(file0, 'w')
                 for k, v in results_out.items():
-                    hf.create_dataset(k, data=v)
+                    if isinstance(v, list):
+                        v = np.array(v)
+                    if v is not None:
+                        hf.create_dataset(k, data=v)
+                    else:
+                        hf.create_dataset(k, data=h5py.Empty("f"))
                 hf.close()
             else:
                 np.save(file0, results_out)
@@ -1165,11 +1170,16 @@ class GLM_single():
                     file0 = os.path.join(outputdir, 'TYPEB_FITHRF.npy')
 
                 print(f'\n*** Saving results to {file0}. ***\n')
-
+                
                 if params['wanthdf5'] == 1:
                     hf = h5py.File(file0, 'w')
                     for k, v in results_out.items():
-                        hf.create_dataset(k, data=v)
+                        if isinstance(v, list):
+                            v = np.array(v)
+                        if v is not None:
+                            hf.create_dataset(k, data=v)
+                        else:
+                            hf.create_dataset(k, data=h5py.Empty("f"))
                     hf.close()
                 else:
                     np.save(file0, results_out)
@@ -1722,7 +1732,12 @@ class GLM_single():
                 if params['wanthdf5'] == 1:
                     hf = h5py.File(file0, 'w')
                     for k, v in outdict.items():
-                        hf.create_dataset(k, data=v)
+                        if isinstance(v, list):
+                            v = np.array(v)
+                        if v is not None:
+                            hf.create_dataset(k, data=v)
+                        else:
+                            hf.create_dataset(k, data=h5py.Empty("f"))
                     hf.close()
                 else:
                     np.save(file0, outdict)


### PR DESCRIPTION
- for cases where the "data" argument of h5py create_dataset are None (as when the user disables GLMdenoise or fracridge), that function errors out
- we resolve this issue using the proper method of saving empty fields/objects in h5py (https://docs.h5py.org/en/stable/high/dataset.html#creating-and-reading-empty-or-null-datasets-and-attributes)