### PR TITLE
Patch for maxpolydeg parameter

### DIFF
--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -462,6 +462,9 @@ class GLM_single():
             params['maxpolydeg'] = np.tile(
                 params['maxpolydeg'], numruns
             ).tolist()
+        
+        if type(params['maxpolydeg']) is list:
+            params['maxpolydeg'] = [np.arange(d + 1) for d in params['maxpolydeg']]    
 
         # normalise maximal amplitude on hrfs
         params['hrftoassume'] = normalisemax(


### PR DESCRIPTION

# Patch for `maxpolydeg` paramater

Apologies for breaking the code. I intended to follow the comments regarding `maxpolydeg`, but I didn’t realize that there was no expansion for the range array in the following code.

To address this issue, I propose a patch that adds an additional check at the bottom to verify if the array is a list. This implementation allows users to create an array with varying degrees for each run.

```python
if 'maxpolydeg' not in params:
	params['maxpolydeg'] = [
                    alt_round(
                        ((self.data[r].shape[-1]*tr)/60)/2)
                    for r in np.arange(numruns)]
  
# ......

if type(params['maxpolydeg']) is int:
	params['maxpolydeg'] = np.tile(
                params['maxpolydeg'], numruns
            ).tolist()
if type(params['maxpolydeg']) is list:
 	params['maxpolydeg'] = [np.arange(d + 1) for d in params['maxpolydeg']]
```

For example if input is an integer: 

```python
params['maxpolydeg'] = 8
numruns = 5
```

Then the constructed maxpolydeg will be 

```python
[array([0, 1, 2, 3, 4, 5, 6, 7, 8]),
 array([0, 1, 2, 3, 4, 5, 6, 7, 8]),
 array([0, 1, 2, 3, 4, 5, 6, 7, 8]),
 array([0, 1, 2, 3, 4, 5, 6, 7, 8]),
 array([0, 1, 2, 3, 4, 5, 6, 7, 8])]
```

If input is an array of degrees: 

```python
params['maxpolydeg'] = [5, 6, 7, 8, 9]
```

Then the constructed maxpolydeg will be 

```python
[array([0, 1, 2, 3, 4, 5]),
 array([0, 1, 2, 3, 4, 5, 6]),
 array([0, 1, 2, 3, 4, 5, 6, 7]),
 array([0, 1, 2, 3, 4, 5, 6, 7, 8]),
 array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])]
```

If no input is provided, the code will first construct a maximum degree for each run and then generate the `maxpolydeg`range arrays accordingly.

A review is still needed, but I believe this patch not only addresses the previous issue but also improves functionality by enabling users to input varying maximum polynomial degrees for each run.

Once again, I apologize for any inconvenience I may have caused.

Best. 