### PR TITLE
fixes: correct pcnum selection in glmsingle.py and session loop data handling in calcbadness.py

### DIFF
--- a/glmsingle/glmsingle.py
+++ b/glmsingle/glmsingle.py
@@ -1549,7 +1549,7 @@ class GLM_single():
                                         optA['extra_regressors'][run_i] = \
                                             np.c_[
                                                 params['extra_regressors'][run_i],
-                                                pcregressors[run_i][:, :n_pc]]
+                                                pcregressors[run_i][:, :pcnum]]
 
                             # fit the entire dataset using the specific frac
                             temp, cache = glm_estimatemodel(

--- a/glmsingle/ssq/calcbadness.py
+++ b/glmsingle/ssq/calcbadness.py
@@ -67,7 +67,8 @@ def calcbadness(xvals, validcolumns, stimix, results, sessionindicator):
         sessions = [1]
     else:
         sessions = range(1, np.max(sessionindicator) + 1)
-
+        
+    resultsdm = copy.deepcopy(results)
     for sess in sessions:
 
         wh = np.flatnonzero(np.array(sessionindicator) == sess)
@@ -80,7 +81,6 @@ def calcbadness(xvals, validcolumns, stimix, results, sessionindicator):
         # std dev of unregularized case
         sd = np.std(results[0][:, whcol], axis=1, ddof=1)
 
-        resultsdm = copy.deepcopy(results)
         for runis in range(len(resultsdm)):
             rundemean = results[runis][:, whcol]-mn[:, np.newaxis]
             resultsdm[runis][:, whcol] = zerodiv(rundemean, sd, val=0, wantcaution=0)


### PR DESCRIPTION
Fixes two small bugs in GLMsingle Python implementation, described in https://github.com/cvnlab/GLMsingle/issues/188:

1. Use cross-validated pcnum instead of total n_pc for PC selection
   - glmsingle.py: Replace n_pc with pcnum when adding principal component regressors to extra_regressors
   - This ensures only the optimal number of PCs (determined via cross-validation) are used rather than all available PCs
   - This is only relevant for scenarios where extra_regressors have been input by the user. Thus this bug is unlikely to have impacted many users to this point.

2. Fix session loop data copying in calcbadness function  
   - calcbadness.py: Move resultsdm = copy.deepcopy(results) outside the 
     session loop to preserve z-score transformations across sessions
   - Previous implementation re-copied results on each session iteration, 
     losing transformations from earlier sessions
   - This issue is only relevant for scenarios where multiple sessions of data have been input simultaneously by the user. Thus this bug is also unlikely to have impacted many users to this point. 

Both fixes ensure the algorithms use intended cross-validated parameters and preserve data transformations as designed. Fixes were validated with a test suite to ensure that the changes have the desired effect.